### PR TITLE
Delete component directive

### DIFF
--- a/src/BladeProvider.php
+++ b/src/BladeProvider.php
@@ -211,13 +211,6 @@ class BladeProvider
             return '<?php endif; ?>';
         };
 
-        $compiler->directive('component', function ($expression) {
-            $expression = rtrim($expression, ')');
-            $expression = ltrim($expression, '(');
-
-            return '<?php $APPLICATION->IncludeComponent('.$expression.'); ?>';
-        });
-
         $compiler->directive('bxComponent', function ($expression) {
             $expression = rtrim($expression, ')');
             $expression = ltrim($expression, '(');


### PR DESCRIPTION
Инициализация bitrix-компонентов с 2018 года идёт через директиву `@bxComponent,` а `@component` считается устаревшим синтаксисом.

Предлагаю отказаться от использования директивы `@component` в проекте полностью, т.к. она конфликтует со стандартной аналогичной blade-директивой, что в свою очередь лишает возможности использования blade-компонентов и слотов.